### PR TITLE
Added unixsocket and flag options to the mysql config

### DIFF
--- a/mysql.cfg
+++ b/mysql.cfg
@@ -5,4 +5,6 @@
     "password"      "example_pass"
     "database"      "example_db"
     "host"          "example.com"
+    "socket"        nil
+    "flags"         nil
 }


### PR DESCRIPTION
I don't know anything about ServerGuard, but these should be options regardless

Ex.
"socket" "/tmp/mysql.sock"
"flags" 65536 // CLIENT_MULTI_STATEMENTS

All major DB modules support connecting with these parameters.
